### PR TITLE
v2.0.0

### DIFF
--- a/.impt.test
+++ b/.impt.test
@@ -1,0 +1,12 @@
+{
+  "deviceGroupId": "14c5a081-16d9-7f17-52fd-0716baf028e7",
+  "timeout": 30,
+  "stopOnFail": false,
+  "allowDisconnect": false,
+  "builderCache": false,
+  "deviceFile": "BQ25895M.device.lib.nut",
+  "testFiles": [
+    "*.test.nut",
+    "tests/**/*.test.nut"
+  ]
+}

--- a/BQ25895M.device.lib.nut
+++ b/BQ25895M.device.lib.nut
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright 2018 Electric Imp
+// Copyright 2018-19 Electric Imp
 //
 // SPDX-License-Identifier: MIT
 //
@@ -45,9 +45,6 @@ const BQ25895M_REG12 = 0x12;
 const BQ25895M_REG13 = 0x13;
 const BQ25895M_REG14 = 0x14;
 
-// Default watchdog reset time in seconds
-const WATCHDOG_RESET_TIME = 30;
-
 // For vbusStatus in getInputStatus() output
 enum BQ25895M_VBUS_STATUS {
     NO_INPUT             = 0x00, // 0 
@@ -77,203 +74,212 @@ enum BQ25895M_CHARGING_FAULT {
 }
 
 // For NTC_FAULT in getChargingFaults() output
-enum BQ25895M_NTC_FAULT{
+enum BQ25895M_NTC_FAULT {
     NORMAL,  // 0
     TS_COLD, // 1
     TS_HOT   // 2
 }
 
+enum BQ25895_DEFUALT_SETTINGS {
+    CRG_VOLTAGE    = 4.208,
+    REG02_DEFAULTS = 0x3D
+}
+
+enum BQ25895M_DEFAULT_SETTINGS {
+    CRG_VOLTAGE    = 4.352,
+    REG02_DEFAULTS = 0x31
+}
+
+enum BQ25895_M_SHARED_DEFAULTS {
+    CRG_CURR         = 2048, 
+    REG03_DEFAULT    = 0x3A,
+    CHARGE_TERM_CURR = 256
+}
+
 class BQ25895M {
 
-    static VERSION = "1.0.0";
+    static VERSION = "2.0.0";
 
     // I2C information
     _i2c = null;
     _addr = null;
 
-    // Watchdog kicker
-    _watchdogtimer = null;
-
-    constructor(i2c, addr=0xD4){
-
+    constructor(i2c, addr = 0xD4) {
         _i2c = i2c;
         _addr = addr;
-
     }
 
-    //PUBLIC METHODS
+    // Initialize battery charger
+    function enable(settings = {}) {
+        // Set to default BQ25895M settings
+        local voltage = BQ25895M_DEFAULT_SETTINGS.CRG_VOLTAGE;
+        local current = BQ25895_M_SHARED_DEFAULTS.CRG_CURR;
 
-    // Initialize battery charger with standard configuration
-    function enable(voltage, current, settings = null) {
+        if ("BQ25895Defaults" in settings && settings.BQ25895Defaults) {
+            voltage = BQ25895_DEFUALT_SETTINGS.CRG_VOLTAGE;
+            current = BQ25895_M_SHARED_DEFAULTS.CRG_CURR;
+            // Set High Voltage DCP and Max Charge Adapter settings
+            _setReg(BQ25895M_REG02, BQ25895_DEFUALT_SETTINGS.REG02_DEFAULTS);
+        } else if ("voltage" in settings && "current" in settings) {
+            voltage = settings.voltage;
+            current = settings.current;
+        }
 
-        // Note: 0x3A is the register default
+        // Disable Watchdog, so settings remain even through sleep cycles
+        _disableWatchdog();
+
         // Enable charger and min system voltage
-        _setReg(BQ25895M_REG03, 0x3a);
+        _setReg(BQ25895M_REG03, BQ25895_M_SHARED_DEFAULTS.REG03_DEFAULT);
 
-        // Note: Register default is 4.352V, need to
-        // start watchdog to keep any other setting
+        // Update settings
         _setChargeVoltage(voltage);
-
-        // Note: Register default is 2048mA, need to
-        // start watchdog to keep any other setting
         _setChargeCurrent(current);
 
-        if (!settings) {
-            settings = {};
-        } 
-
-        if (("setChargeCurrentOptimizer" in settings) && settings["setChargeCurrentOptimizer"]) {
-            _setRegBit(BQ25895M_REG09, 7, 1); // enable charge current optimizer
+        if (("setChargeCurrentOptimizer" in settings) && settings.setChargeCurrentOptimizer) {
+            // Enable charge current optimizer
+            _setRegBit(BQ25895M_REG09, 7, 1); 
         } else {
-            _setRegBit(BQ25895M_REG09, 7, 0); // disable charge current optimizer
+            // Disable charge current optimizer
+            _setRegBit(BQ25895M_REG09, 7, 0); 
         }
     
-        if (("setChargeTerminationCurrentLimit" in settings) && settings["setChargeTerminationCurrentLimit"]) {
+        if (("setChargeTerminationCurrentLimit" in settings) && settings.setChargeTerminationCurrentLimit) {
             _setChargeTerminationCurrent(settings.setChargeTerminationCurrentLimit);        
         } else {
-            _setChargeTerminationCurrent(256); // set default charge termination current limit of 256mA
+            // Set default charge termination current limit of 256mA
+            _setChargeTerminationCurrent(BQ25895_M_SHARED_DEFAULTS.CHARGE_TERM_CURR); 
         }
-
-        // Make sure settings don't revert to chip defaults
-        _kickWatchdog();
     }
 
     // Clear the enable charging bit, device will not charge until enableCharging() is called again
     function disable() {
+        // Disable Watchdog, to keep charger disabled setting even through sleep cycles
+        _disableWatchdog();
 
         local rd = _getReg(BQ25895M_REG03);
-        rd = rd & ~(1 << 4); // clear CHG_CONFIG bits
 
+        // Clear CHG_CONFIG bits
+        rd = rd & ~(1 << 4); 
         _setReg(BQ25895M_REG03, rd);
-
-        // Start kicking watchdog, since default is
-        // to enable charging
-        _kickWatchdog();
-
     }
 
     // Returns the target battery voltage
     function getChargeVoltage() {
-
         local rd = _getReg(BQ25895M_REG06);
-        local chrgVlim = ((rd >> 2) * 16) + 3840; // 16mV is the resolution, 3840mV must be added as the offset
 
+        // 16mV is the resolution, 3840mV must be added as the offset
+        local chrgVlim = ((rd >> 2) * 16) + 3840; 
         // Convert mV to Volts
         return chrgVlim / 1000.0;
-
     }
 
     // Returns the battery voltage based on the ADC conversion
     function getBatteryVoltage() {
-
-        _convStart(); // Kick ADC
-
+        // Kick ADC
+        _convStart(); 
         local rd = _getReg(BQ25895M_REG0E);
-        local battV = (2304 + (20 * (rd & 0x7f))); // 2304mV must be added as the offset, 20mV is the resolution
 
+        // 2304mV must be added as the offset, 20mV is the resolution
+        local battV = (2304 + (20 * (rd & 0x7f))); 
         // Convert mV to Volts
         return battV / 1000.0;
-
     }
 
     // Returns the VBUS voltage based on the ADC conversion, this is the input voltage
     function getVBUSVoltage() {
-
-        _convStart(); // Kick ADC
-
+        // Kick ADC
+        _convStart(); 
         local rd = _getReg(BQ25895M_REG11);
-        local vBusV = (2600 + (100 * (rd & 0x7f))) // 2600mV must be added as the offset, 100mV is the resolution
 
+        // 2600mV must be added as the offset, 100mV is the resolution
+        local vBusV = (2600 + (100 * (rd & 0x7f))) 
         // Convert mV to Volts
         return vBusV / 1000.0;
-
     }
 
     // Returns the system voltage based on the ADC conversion
     function getSystemVoltage() {
-
-        _convStart(); // Kick ADC
-
+        // Kick ADC
+        _convStart(); 
         local rd = _getReg(BQ25895M_REG0F);
-        local sysV = (2304 + (20 * (rd & 0x7f))); // 2304mV must be added as the offset, 20mV is the resolution
 
-        // Convert mV to Volts
+        // 2304mV must be added as the offset, 20mV is the resolution
+        local sysV = (2304 + (20 * (rd & 0x7f))); 
         return sysV;
-
     }
     
     // Returns the charging mode and input current limit in a table
     function getInputStatus(){
-        
-        local inputStatus = {"vbusStatus" : 0, "inputCurrentLimit" : 0};
-        
-        local rd = _getReg(BQ25895M_REG0B); // Read VBUS status reg
+        local inputStatus = {
+            "vbusStatus"        : 0, 
+            "inputCurrentLimit" : 0
+        };
+
+        // Read VBUS status reg
+        local rd = _getReg(BQ25895M_REG0B); 
         inputStatus.vbusStatus <- rd & 0xE0;
         
-        local rd = _getReg(BQ25895M_REG00);
-        inputStatus.inputCurrentLimit <- (100 + (50 * (rd & 0x3f))); // 100mA offset, 50mA resolution
+        // Read input current limit reg
+        rd = _getReg(BQ25895M_REG00);
+        // 100mA offset, 50mA resolution
+        inputStatus.inputCurrentLimit <- (100 + (50 * (rd & 0x3f))); 
         
         return inputStatus;
     }
 
     // Returns the measured charge current based on the ADC conversion
     function getChargingCurrent() {
-
-        _convStart(); // Kick ADC
-
+        // Kick ADC
+        _convStart(); 
         local rd = _getReg(BQ25895M_REG12);
-        local iChgr = (50 * (rd & 0x7f)); // 50mA is the resolution
 
+        // 50mA is the resolution
+        local iChgr = (50 * (rd & 0x7f)); 
         return iChgr;
-
     }
 
     // Returns the charging status: Not Charging, Pre-charge, Fast Charging, Charge Termination Good
     function getChargingStatus() {
-
         local rd = _getReg(BQ25895M_REG0B);
-        rd = rd & 0x18;
-
-        return rd;
-
+        return rd & 0x18;
     }
 
     // Returns the possible charger faults in an array: watchdogFault, boostFault, chrgFault, battFault, ntcFault
     function getChargerFaults() {
-
-        local chargerFaults = {"watchdogFault" : 0, "boostFault" : 0, "chrgFault" : 0, "battFault" : 0, "ntcFault" : 0};
+        local chargerFaults = {
+            "watchdogFault" : 0, 
+            "boostFault"    : 0, 
+            "chrgFault"     : 0, 
+            "battFault"     : 0, 
+            "ntcFault"      : 0
+        };
 
         local rd = _getReg(BQ25895M_REG0C);
-
         chargerFaults.watchdogFault <- rd >> 7;
         chargerFaults.boostFault <- rd >> 6;
-        chargerFaults.chrgFault <- rd & 0x30; // normal, input fault, thermal shutdown, charge safety timer expiration
+        // Normal, input fault, thermal shutdown, charge safety timer expiration
+        chargerFaults.chrgFault <- rd & 0x30; 
         chargerFaults.battFault <- rd >> 3;
-        chargerFaults.ntcFault <- rd & 0x07; // normal, TS cold, TS hot
+        // Normal, TS cold, TS hot 
+        // For compatibility between BQ25895 & BQ25895M drop the top bit, it is not needed to determine NTC fault
+        chargerFaults.ntcFault <- rd & 0x03; 
 
         return chargerFaults;
-
     }
 
     // Restore default device settings
     function reset() {
-
-        // Stop the watchdog timer, since we are resetting to defaults
-        if (_watchdogtimer != null) imp.cancelwakeup(_watchdogtimer);
-
         // Set reset bit
         _setRegBit(BQ25895M_REG14, 7, 1);
         imp.sleep(0.01);
         // Clear reset bit
         _setRegBit(BQ25895M_REG14, 7, 0);
-
     }
 
     //-------------------- PRIVATE METHODS --------------------//
 
     // Set target battery voltage
     function _setChargeVoltage(vreg) {
-
         // Convert to mV
         vreg *= 1000;
 
@@ -287,86 +293,80 @@ class BQ25895M {
         }
 
         local rd = _getReg(BQ25895M_REG06);
-        rd = rd & ~(0xFC); // clear bits
-        rd = rd | (0xFC & (((vreg - 3840) / 16).tointeger()) << 2); // 3840mV is the default offset, 16mV is the resolution
+        // Clear bits
+        rd = rd & ~(0xFC); 
+        // 3840mV is the default offset, 16mV is the resolution
+        rd = rd | (0xFC & (((vreg - 3840) / 16).tointeger()) << 2); 
 
         _setReg(BQ25895M_REG06, rd);
-
     }
 
     // Set fast charge current
     function _setChargeCurrent(ichg) {
-
         // Check that input is within accepted range
-        if (ichg < 0) { // charge current must be greater than 0
+        if (ichg < 0) { 
+            // Charge current must be greater than 0
             ichg = 0;
-        } else if (ichg > 5056) { // max charge current from device datasheet
+        } else if (ichg > 5056) { 
+            // Max charge current from device datasheet
             ichg = 5056;
         }
 
         local rd = _getReg(BQ25895M_REG04);
-        rd = rd & ~(0x7F); // clear bits
-        rd = rd | (0x7F & ichg / 64); // 64mA is the resolution
+        // Clear bits
+        rd = rd & ~(0x7F); 
+        // 64mA is the resolution
+        rd = rd | (0x7F & ichg / 64); 
 
         _setReg(BQ25895M_REG04, rd);
-
     }
     
     function _setChargeTerminationCurrent(iterm){
-        
         // Check that input is within accepted range
-        if (iterm < 64) { // charge current must be greater than 0
+        if (iterm < 64) { 
+            // charge current must be greater than 0
             iterm = 64;
-        } else if (iterm >= 1024) { // max charge current from device datasheet
+        } else if (iterm >= 1024) { 
+            // max charge current from device datasheet
             iterm = 1024;
         }
 
         local rd = _getReg(BQ25895M_REG05);
-        rd = rd & ~(0x0F); // clear bits
-        rd = rd | (0x0F & (iterm - 64) / 64); // 64mA is the resolution
+        // clear bits
+        rd = rd & ~(0x0F); 
+        // 64mA is the resolution
+        rd = rd | (0x0F & (iterm - 64) / 64); 
 
         _setReg(BQ25895M_REG05, rd); 
-        
     }
 
-    function _kickWatchdog() {
-
-        _setRegBit(BQ25895M_REG03, 6, 1); // Kick watchdog
-
-        if (_watchdogtimer != null) imp.cancelwakeup(_watchdogtimer);
-        _watchdogtimer = imp.wakeup(WATCHDOG_RESET_TIME, _kickWatchdog.bindenv(this));
-
+    function _disableWatchdog() {
+        _setRegBit(BQ25895M_REG07, 5, 0);
+        _setRegBit(BQ25895M_REG07, 4, 0);
     }
 
     function _convStart() {
-
         // call before ADC conversion
         _setRegBit(BQ25895M_REG02, 7, 1);
-
     }
 
     function _getReg(reg) {
-
         local result = _i2c.read(_addr, reg.tochar(), 1);
         if (result == null) {
             throw "I2C read error: " + _i2c.readerror();
         }
         return result[0];
-
     }
 
     function _setReg(reg, val) {
-
         local result = _i2c.write(_addr, format("%c%c", reg, (val & 0xff)));
         if (result) {
             throw "I2C write error: " + result;
         }
         return result;
-
     }
 
     function _setRegBit(reg, bit, state) {
-
         local val = _getReg(reg);
         if (state == 0) {
             val = val & ~(0x01 << bit);
@@ -374,7 +374,6 @@ class BQ25895M {
             val = val | (0x01 << bit);
         }
         return _setReg(reg, val);
-
     }
 
 }

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,9 +1,8 @@
 # Setting Up The BQ25895M For Your Battery #
 
-
 ## Important Battery Parameters ##
 
-In order to set up the BQ25895M properly there are two important parameters that you need know for your specific battery: the charging voltage and the charging current. 
+In order to set up the BQ25895M properly there are two important parameters that you need know for your specific battery: the charging voltage and the charging current limit. 
 
 ## Finding Charging Parameters ##
 
@@ -11,14 +10,16 @@ In this example we will be looking at this [3.7V 2000mAh]( https://www.adafruit.
 
 In Section 3, Form 1 there is a table describing the battery's rated performance characteristics. Looking at the fourth row of the table, we can see the charging voltage is 4.2V. Row six shows the quick charge current is 1CA. The C represents the battery capacity. Row 1 shows that the capacity is 2000mAh. This means that the quick charge current = 1 * 2000 mA = 2000mA.
 
-It is very important to find the correct values for these two parameters as exceeding them can damage your battery.
+It is very important to find the correct values for these two parameters as exceeding them can damage your battery. 
+
+**Note:** The default settings for the BQ25895M are not compatible with this example battery. Therefore it is very important to enable the battery with the correct settings as soon as the device boots. 
 
 ## Example ##
 
 ```squirrel
-#require "BQ25895M.device.lib.nut:1.0.0"
+#require "BQ25895M.device.lib.nut:2.0.0"
 
-// Choose an impC001 I2C bus and confiure it
+// Choose an impC001 I2C bus and configure it
 local i2c = hardware.i2cKL;
 i2c.configure(CLOCK_SPEED_400_KHZ);
 
@@ -26,5 +27,27 @@ i2c.configure(CLOCK_SPEED_400_KHZ);
 batteryCharger <- BQ25895M(i2c);
 
 // Configure the charger to charge at 4.2V to a maximum of 2000mA
-batteryCharger.enable(4.2, 2000); 
+settings <- {
+    "voltage" : 4.2, 
+    "current" : 2000
+}
+
+batteryCharger.enable(settings); 
+```
+
+The example battery is compatible with the default settings for the BQ25895, so it would be acceptable to use the *BQ25895Defaults* flag when enabling this battery.
+
+```squirrel
+#require "BQ25895M.device.lib.nut:2.0.0"
+
+// Choose an impC001 I2C bus and configure it
+local i2c = hardware.i2cKL;
+i2c.configure(CLOCK_SPEED_400_KHZ);
+
+// Instantiate a BQ25895M object
+batteryCharger <- BQ25895M(i2c);
+
+// Configure the charger to charge at 4.208V to a maximum of 2048mA
+settings <- { "BQ25895Defaults" : true };
+batteryCharger.enable(settings); 
 ```

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -2,21 +2,22 @@
 
 ## Important Battery Parameters ##
 
-In order to set up the BQ25895M properly there are two important parameters that you need know for your specific battery: the charging voltage and the charging current limit. 
+In order to set up the BQ25895M properly there are two important parameters that you need know for your specific battery: the charging voltage and the charging current limit.
 
 ## Finding Charging Parameters ##
 
 In this example we will be looking at this [3.7V 2000mAh]( https://www.adafruit.com/product/2011?gclid=EAIaIQobChMIh7uL6pP83AIVS0sNCh1NNQUsEAQYAiABEgKFA_D_BwE) battery from Adafruit. This battery is labelled 3.7V but this is the nominal voltage and not the voltage required for charging. The label also shows its capacity to be 2000mAh but provides no specific charging current. This is not enough information to determine our charging parameters so we must look for more information in the battery's [datasheet](https://cdn-shop.adafruit.com/datasheets/LiIon2000mAh37V.pdf).
 
-In Section 3, Form 1 there is a table describing the battery's rated performance characteristics. Looking at the fourth row of the table, we can see the charging voltage is 4.2V. Row six shows the quick charge current is 1CA. The C represents the battery capacity. Row 1 shows that the capacity is 2000mAh. This means that the quick charge current = 1 * 2000 mA = 2000mA.
+In Section 3, Form 1 there is a table describing the battery's rated performance characteristics. Looking at the fourth row of the table, we can see the charging voltage is 4.2V. Row six shows the quick charge current is 1CA. The C represents the battery capacity. Row 1 shows that the capacity is 2000mAh. This means that the quick charge current = 1 * 2000mA = 2000mA.
 
-It is very important to find the correct values for these two parameters as exceeding them can damage your battery. 
+It is very important to find the correct values for these two parameters as exceeding them can damage your battery.
 
-**Note:** The default settings for the BQ25895M are not compatible with this example battery. Therefore it is very important to enable the battery with the correct settings as soon as the device boots. 
-
-## Example ##
+**IMPORTANT** The default settings for the BQ25895M are not compatible with this example battery. Therefore it is very important to enable the battery with the correct settings as soon as the device boots. You do this by as follows:
 
 ```squirrel
+/*********** WORKING WITH THE BQ25895M **********/
+
+// Import the BQ25895M driver
 #require "BQ25895M.device.lib.nut:2.0.0"
 
 // Choose an impC001 I2C bus and configure it
@@ -27,17 +28,17 @@ i2c.configure(CLOCK_SPEED_400_KHZ);
 batteryCharger <- BQ25895M(i2c);
 
 // Configure the charger to charge at 4.2V to a maximum of 2000mA
-settings <- {
-    "voltage" : 4.2, 
-    "current" : 2000
-}
-
-batteryCharger.enable(settings); 
+local settings = { "voltage" : 4.2,
+                   "current" : 2000 };
+batteryCharger.enable(settings);
 ```
 
-The example battery is compatible with the default settings for the BQ25895, so it would be acceptable to use the *BQ25895Defaults* flag when enabling this battery.
+The example battery is, however, compatible with the default settings for the BQ25895, so it would be acceptable to use the built-in *BQ25895Defaults* setting when enabling this battery:
 
 ```squirrel
+/*********** WORKING WITH THE BQ25895 **********/
+
+// Import the BQ25895 driver
 #require "BQ25895M.device.lib.nut:2.0.0"
 
 // Choose an impC001 I2C bus and configure it
@@ -48,6 +49,6 @@ i2c.configure(CLOCK_SPEED_400_KHZ);
 batteryCharger <- BQ25895M(i2c);
 
 // Configure the charger to charge at 4.208V to a maximum of 2048mA
-settings <- { "BQ25895Defaults" : true };
-batteryCharger.enable(settings); 
+local settings = { "BQ25895Defaults" : true };
+batteryCharger.enable(settings);
 ```

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2018 Electric Imp
+Copyright 2018-19 Electric Imp
 
 SPDX-License-Identifier: MIT
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Nothing.
 // Configure battery charger with charge voltage of 4.2V and current limit of 1000mA.
 // Enable charge current optimizer and set charge termination current lim to 128
 
-settings <- {"chargeCurrentOptimizer":1, "setChargeTerminationCurrentLimit":128};
+settings <- {"chargeCurrentOptimizer":true, "setChargeTerminationCurrentLimit":128};
 batteryCharger.enable(4.2, 1000, settings);
 ```
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ local current = batteryCharger.getChargingCurrent();
 server.log("Current (charging): " + current + "mA");
 ```
 ### getInputStatus() ###
-This method returns the type of power source connected to the charger input as well as the resulting input current limit.
+This method returns the type of power source connected to the charger as well as the resulting input current limit.
 
 #### Return Value ####
 Table &mdash; An input status report *(see below)*

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This method configures and enables the battery charger with settings to perform 
 
 | Table Key | Value | Description |
 | --- | --- | --- |
-| *setChargeCurrentOptimizer* | *true* | Identify maximum power point without overload the input source |
+| *setChargeCurrentOptimizer* | `true` | Identify maximum power point without overloading the input source |
 
 #### Return Value ####
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 
+
 # BQ25895M #
 
 The [BQ25895M](http://www.ti.com/lit/ds/symlink/bq25895m.pdf) is switch-mode battery charge and system power path management device for single-cell Li-Ion and Li-polymer batteries. It supports high input voltage fast charging and communicates over an I&sup2;C interface.
@@ -153,6 +154,65 @@ Integer &mdash; The charging current in mA.
 ```squirrel
 local current = batteryCharger.getChargingCurrent();
 server.log("Current (charging): " + current + "mA");
+```
+### getInputStatus() ###
+This method returns the type of power source connected to the charger input as well as the resulting input current limit.
+
+#### Return Value ####
+Table &mdash; An input status report *(see below)*
+
+| Key| Type | Description |
+| --- | --- | --- |
+| *vbusStatus* | integer| Possible input states, see table below for details |
+| *inputCurrentLimit* | integer| 100-3250mA |
+
+#### VBUS Status ####
+
+| VBUS Status Constant | Value |
+| --- | --- |
+| *BQ25895M_VBUS_STATUS.NO_INPUT* | 0x00 |
+| *BQ25895M_VBUS_STATUS.USB_HOST_SDP* | 0x20 |
+| *BQ25895M_VBUS_STATUS.USB_CDP* | 0x40 |
+| *BQ25895M_VBUS_STATUS.USB_DCP* | 0x60 |
+| *BQ25895M_VBUS_STATUS.ADJUSTABLE_HV_DCP* | 0x80 |
+| *BQ25895M_VBUS_STATUS.UNKNOWN_ADAPTER* | 0xA0 |
+| *BQ25895M_VBUS_STATUS.NON_STANDARD_ADAPTER* | 0xC0 |
+| *BQ25895M_VBUS_STATUS.OTG* | 0xE0 |
+
+#### Example ####
+
+```squirrel
+local inputStatus = batteryCharger.getInputStatus();
+
+    switch(inputStatus.vbusStatus) {
+      case BQ25895M_VBUS_STATUS.NO_INPUT:
+        server.log("No Input");
+        break;
+      case BQ25895M_VBUS_STATUS.USB_HOST_SDP:
+        server.log("USB Host SDP");
+        break;
+      case BQ25895M_VBUS_STATUS.USB_CDP:
+        server.log("USB CDP");
+        break;
+      case BQ25895M_VBUS_STATUS.USB_DCP:
+        server.log("USB DCP");
+        break;
+      case BQ25895M_VBUS_STATUS.ADJUSTABLE_HV_DCP:
+        server.log("Adjustable High Voltage DCP");
+        break;
+          case BQ25895M_VBUS_STATUS.UNKNOWN_ADAPTER:
+        server.log("Unknown Adapter");
+        break;
+      case BQ25895M_VBUS_STATUS.NON_STANDARD_ADAPTER:
+        server.log("Non Standard Adapter");
+        break;
+      case BQ25895M_VBUS_STATUS.OTG:
+        server.log("OTG");
+        break;
+    }
+
+server.log("Input Current Limit = " + inputStatus.inputCurrentLimit);
+
 ```
 
 ### getChargingStatus() ###

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This method configures and enables the battery charger with settings to perform 
 | Table Key | Value | Description |
 | --- | --- | --- |
 | *setChargeCurrentOptimizer* | `true` | Identify maximum power point without overloading the input source |
+| *setChargeTerminationCurrentLimit*	| 64-1024mA | Charge cycle is terminated when battery voltage is above recharge threwshold and the current is below *termination current* |
 
 #### Return Value ####
 
@@ -61,8 +62,11 @@ Nothing.
 #### Example ####
 
 ```squirrel
-// Configure battery charger with charge voltage of 4.2V and current limit of 1000mA
-batteryCharger.enable(4.2, 1000);
+// Configure battery charger with charge voltage of 4.2V and current limit of 1000mA.
+// Enable charge current optimizer and set charge termination current lim to 128
+
+settings <- {"chargeCurrentOptimizer":1, "setChargeTerminationCurrentLimit":128};
+batteryCharger.enable(4.2, 1000, settings);
 ```
 
 ### disable() ###
@@ -156,7 +160,7 @@ local current = batteryCharger.getChargingCurrent();
 server.log("Current (charging): " + current + "mA");
 ```
 ### getInputStatus() ###
-This method returns the type of power source connected to the charger as well as the resulting input current limit.
+This method returns the type of power source connected to the charger input as well as the resulting input current limit.
 
 #### Return Value ####
 Table &mdash; An input status report *(see below)*

--- a/tests/StubbedI2C.device.nut
+++ b/tests/StubbedI2C.device.nut
@@ -1,0 +1,107 @@
+// MIT License
+//
+// Copyright 2019 Electric Imp
+//
+// SPDX-License-Identifier: MIT
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+class StubbedI2C {
+
+    _writeBuffer = null;
+    _readResp    = null;
+    _error       = null;
+    _enabled     = null;
+
+    constructor() {
+        _writeBuffer = {};
+        _readResp    = {};
+        _error       = 0;
+        _enabled     = false;
+    }
+
+    function configure(clockSpeed) {
+        _enabled = true;
+    }
+
+    function disable() {
+        _enabled = false;
+    }
+
+    function read(devAddr, regAddr, numBytes) {
+        if (!_enabled) {
+            _error = -13;   // NOT_ENABLED
+            return null;
+        }
+
+        if (devAddr in _readResp && regAddr in _readResp[devAddr]) {
+            local data = _readResp[devAddr][regAddr];
+            return data;
+        } else {
+            _error = "No data at device address register in read buffer.";
+        }
+
+        return null;
+    }
+
+    function readerror() {
+        // Store current error
+        local err = _error;
+        // Reset stored error to default 0: NO_ERROR
+        _error = 0;
+        // Return the current error
+        return err;
+    }
+
+    // Just accept write data, and return i2c error code
+    function write(devAddr, regPlusData) {
+        if (devAddr in _writeBuffer) {
+            local data = _writeBuffer[devAddr];
+            _writeBuffer[devAddr] = data + regPlusData;
+        } else {
+            _writeBuffer[devAddr] <- regPlusData;
+        }
+
+        // Return i2c error code 0: NO_ERROR, -13: NOT_ENABLED
+        return (_enabled) ? 0 : -13;
+    }
+
+    // Store read response in a table
+    function _setReadResp(devAddr, regAddr, data) {
+        if (devAddr in _readResp) {
+            _readResp[devAddr][regAddr] <- data;
+        } else {
+            _readResp[devAddr] <- {};
+            _readResp[devAddr][regAddr] <- data;
+        }
+    }
+
+    function _clearReadResp() {
+        _readResp = {};
+    }
+
+    function _getWriteBuffer(devAddr) {
+        return (devAddr in _writeBuffer) ? _writeBuffer[devAddr] : null;
+    }
+
+    function _clearWriteBuffer() {
+        _writeBuffer = {};
+    }
+
+}

--- a/tests/StubbedI2CTests.device.test.nut
+++ b/tests/StubbedI2CTests.device.test.nut
@@ -1,0 +1,619 @@
+// MIT License
+//
+// Copyright 2015-19 Electric Imp
+//
+// SPDX-License-Identifier: MIT
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+@include __PATH__+"/StubbedI2C.device.nut"
+
+const BQ25895M_DEFAULT_I2C_ADDR = 0xD4;
+
+class StubbedHardwareTests extends ImpTestCase {
+    
+    _i2c    = null;
+    _charger = null;
+
+    function _cleari2cBuffers() {
+        // Clear all buffers
+        _i2c._clearWriteBuffer();
+        _i2c._clearReadResp();
+    }
+
+    function setUp() {
+        _i2c = StubbedI2C();
+        _i2c.configure(CLOCK_SPEED_400_KHZ);
+        _charger = BQ25895M(_i2c);
+        return "Stubbed hardware test setup complete.";
+    }    
+
+    function testConstructorDefaultParams() {
+        assertEqual(BQ25895M_DEFAULT_I2C_ADDR, _charger._addr, "Defult i2c address did not match expected");
+        return "Constructor default params test complete.";
+    }
+
+    function testConstructorOptionalParams() {
+        local customAddr = 0xBA;
+        local _charger = BQ25895M(_i2c, customAddr);
+        assertEqual(customAddr, _charger._addr, "Non default i2c address did not match expected");
+        return "Constructor optional params test complete.";
+    }
+
+    function testEnableDefaults() {
+        // Note: Limitation of stubbed class, all read values are set before enable
+        // so 2 set bit calls back to back are not effected by register write commands
+        _cleari2cBuffers();
+        // Set readbuffer values
+        // REG04 to 0x00
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG04.tochar(), "\x00");    
+        // REG05 to 0x10
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG05.tochar(), "\x10");
+        // REG06 to 0x02, 
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG06.tochar(), "\x02");
+        // REG07 to 0x9D,
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG07.tochar(), "\x9D");
+        // REG09 to 0xC4
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG09.tochar(), "\xC4");
+
+        // Test empty settings table
+        _charger.enable();
+
+        // Write commands in enable:
+            // (REG07 bit5 to 0, REG07 bit4 to 0) Disable watchdog 
+            // (REG03 0x3A) Enable charger and min system voltage 
+            // (REG06 0x82) Set charge voltage, 4.352
+            // (REG04 0x20) Set charge current, 2048
+            // (REG09 bit7 to 0) Set charge current optimizer to default 0
+            // (REG05 0x13) Set charge termination current limit to default, 256
+        local expected = format("%c%s%c%s%c%s%c%s%c%s%c%s%c%s", 
+            BQ25895M_REG07, "\x9D",
+            BQ25895M_REG07, "\x8D",
+            BQ25895M_REG03, "\x3A",
+            BQ25895M_REG06, "\x82",
+            BQ25895M_REG04, "\x20",
+            BQ25895M_REG09, "\x44",
+            BQ25895M_REG05, "\x13"        
+        );
+        local actual = _i2c._getWriteBuffer(BQ25895M_DEFAULT_I2C_ADDR);
+        assertEqual(expected, actual, "Enable with defualt params did not match expected results");
+        
+        _cleari2cBuffers();
+        return "Enable with defualt params test passed";
+    }
+
+    function testEnableBQ25895Defaults() {
+        // Note: Limitation of stubbed class, all read values are set before enable
+        // so 2 set bit calls back to back are not effected by register write commands
+        _cleari2cBuffers();
+        // Set readbuffer values
+        // REG04 to 0x00
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG04.tochar(), "\x00");    
+        // REG05 to 0x10
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG05.tochar(), "\x10");
+        // REG06 to 0x02, 
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG06.tochar(), "\x02");
+        // REG07 to 0xAD,
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG07.tochar(), "\xAD");
+        // REG09 to 0xC4
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG09.tochar(), "\xC4");
+
+        // Test that BQ25895Defaults are set (even if current and voltage are passed in)
+        _charger.enable({
+            "BQ25895Defaults" : true,
+            "voltage" : 3.0,
+            "current" : 1803
+        });
+
+        // Write commands in enable:
+            // (REG02 0x3D) Enable HVDCP_EN & MAXC_EN handshakes
+            // (REG07 bit5 to 0, REG07 bit4 to 0) Disable watchdog 
+            // (REG03 0x3A) Enable charger and min system voltage 
+            // (REG06 0x5E) Set charge voltage, 4.208
+            // (REG04 0x20) Set charge current, 2048
+            // (REG09 bit7 to 0) Set charge current optimizer to default 0
+            // (REG05 0x13) Set charge termination current limit to default, 256
+        local expected = format("%c%s%c%s%c%s%c%s%c%s%c%s%c%s%c%s", 
+            BQ25895M_REG02, "\x3D",            
+            BQ25895M_REG07, "\x8D",
+            BQ25895M_REG07, "\xAD", // Note this val is not effected by previous write!!!
+            BQ25895M_REG03, "\x3A",
+            BQ25895M_REG06, "\x5E",
+            BQ25895M_REG04, "\x20",
+            BQ25895M_REG09, "\x44",
+            BQ25895M_REG05, "\x13"        
+        );
+        local actual = _i2c._getWriteBuffer(BQ25895M_DEFAULT_I2C_ADDR);
+        assertEqual(expected, actual, "Enable with defualt BQ25895 params did not match expected results");
+        
+        _cleari2cBuffers();
+        return "Enable with defualt BQ25895 params test passed";
+    }
+
+    function testEnableCustomVoltAndCurr() {
+        // Note: Limitation of stubbed class, all read values are set before enable
+        // so 2 set bit calls back to back are not effected by register write commands
+        _cleari2cBuffers();
+        // Set readbuffer values
+        // REG04 to 0x00
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG04.tochar(), "\x80");    
+        // REG05 to 0x10
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG05.tochar(), "\x10");
+        // REG06 to 0x02, 
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG06.tochar(), "\x02");
+        // REG07 to 0xAD,
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG07.tochar(), "\x9D");
+        // REG09 to 0xC4
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG09.tochar(), "\xC4");
+
+        // Test that BQ25895Defaults are not set and current and voltage settings are configured
+        _charger.enable({
+            "BQ25895Defaults" : false,
+            "voltage" : 4.2,
+            "current" : 2000
+        });
+
+        // Write commands in enable:
+            // (REG07 bit5 to 0, REG07 bit4 to 0) Disable watchdog 
+            // (REG03 0x3A) Enable charger and min system voltage 
+            // (REG06 0x5A) Set charge voltage, 4.2 
+            // (REG04 0x9F) Set charge current, 2000
+            // (REG09 bit7 to 0) Set charge current optimizer to default 0
+            // (REG05 0x13) Set charge termination current limit to default, 256
+        local expected = format("%c%s%c%s%c%s%c%s%c%s%c%s%c%s",          
+            BQ25895M_REG07, "\x9D",
+            BQ25895M_REG07, "\x8D",
+            BQ25895M_REG03, "\x3A",
+            BQ25895M_REG06, "\x5A", 
+            BQ25895M_REG04, "\x9F",
+            BQ25895M_REG09, "\x44",
+            BQ25895M_REG05, "\x13"        
+        );
+        local actual = _i2c._getWriteBuffer(BQ25895M_DEFAULT_I2C_ADDR);
+        assertEqual(expected, actual, "Enable with custom voltage and current params did not match expected results");
+        
+        _cleari2cBuffers();
+        return "Enable with custom voltage and current params test passed";
+    }
+
+    function testEnableVCOutOfRange() {
+        // Note: Limitation of stubbed class, all read values are set before enable
+        // so 2 set bit calls back to back are not effected by register write commands
+        _cleari2cBuffers();
+        // Set readbuffer values
+        // REG04 to 0x00
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG04.tochar(), "\x00");    
+        // REG05 to 0x10
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG05.tochar(), "\x10");
+        // REG06 to 0x02, 
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG06.tochar(), "\x02");
+        // REG07 to 0xAD,
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG07.tochar(), "\x9D");
+        // REG09 to 0xC4
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG09.tochar(), "\xC4");
+
+        // Test that current and voltage are limited
+        _charger.enable({
+            "voltage" : 5.0,
+            "current" : 6000
+        });
+
+        // Write commands in enable:
+            // (REG07 bit5 to 0, REG07 bit4 to 0) Disable watchdog 
+            // (REG03 0x3A) Enable charger and min system voltage 
+            // (REG06 0xC2) Set charge voltage, 5.0 
+            // (REG04 0xCF) Set charge current, 6000
+            // (REG09 bit7 to 0) Set charge current optimizer to default 0
+            // (REG05 0x13) Set charge termination current limit to default, 256
+        local expected = format("%c%s%c%s%c%s%c%s%c%s%c%s%c%s",          
+            BQ25895M_REG07, "\x9D",
+            BQ25895M_REG07, "\x8D",
+            BQ25895M_REG03, "\x3A",
+            BQ25895M_REG06, "\xC2", 
+            BQ25895M_REG04, "\x4F", 
+            BQ25895M_REG09, "\x44",
+            BQ25895M_REG05, "\x13"        
+        );
+        local actual = _i2c._getWriteBuffer(BQ25895M_DEFAULT_I2C_ADDR);
+        assertEqual(expected, actual, "Enable with out of range high voltage and current params did not match expected results");
+        
+        _cleari2cBuffers();
+        // Set readbuffer values
+        // REG04 to 0x00
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG04.tochar(), "\x80");    
+        // REG05 to 0x10
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG05.tochar(), "\x10");
+        // REG06 to 0x02, 
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG06.tochar(), "\x02");
+        // REG07 to 0xAD,
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG07.tochar(), "\x9D");
+        // REG09 to 0xC4
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG09.tochar(), "\xC4");
+
+        // Test that current and voltage are limited
+        _charger.enable({
+            "voltage" : 3.0,
+            "current" : -1
+        });
+
+        // Write commands in enable:
+            // (REG07 bit5 to 0, REG07 bit4 to 0) Disable watchdog 
+            // (REG03 0x3A) Enable charger and min system voltage 
+            // (REG06 0x02) Set charge voltage, 3.0 
+            // (REG04 0x00) Set charge current, -1
+            // (REG09 bit7 to 0) Set charge current optimizer to default 0
+            // (REG05 0x13) Set charge termination current limit to default, 256
+        local expected = format("%c%s%c%s%c%s%c%s%c%s%c%s%c%s",          
+            BQ25895M_REG07, "\x9D",
+            BQ25895M_REG07, "\x8D",
+            BQ25895M_REG03, "\x3A",
+            BQ25895M_REG06, "\x02", 
+            BQ25895M_REG04, "\x80",
+            BQ25895M_REG09, "\x44",
+            BQ25895M_REG05, "\x13"        
+        );
+        local actual = _i2c._getWriteBuffer(BQ25895M_DEFAULT_I2C_ADDR);
+        assertEqual(expected, actual, "Enable with out of range low voltage and current params did not match expected results");
+        
+        _cleari2cBuffers();
+        return "Enable with out of range voltage and current params test passed";
+    }
+
+    function testEnableSetChargeCurrentOptimizer() {
+        // Note: Limitation of stubbed class, all read values are set before enable
+        // so 2 set bit calls back to back are not effected by register write commands
+        _cleari2cBuffers();
+        // Set readbuffer values
+        // REG04 to 0x00
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG04.tochar(), "\x00");    
+        // REG05 to 0x10
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG05.tochar(), "\x10");
+        // REG06 to 0x02, 
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG06.tochar(), "\x02");
+        // REG07 to 0x9D,
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG07.tochar(), "\x9D");
+        // REG09 to 0x44
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG09.tochar(), "\x44");
+
+        // Test setChargeCurrentOptimizer
+        _charger.enable({
+            "setChargeCurrentOptimizer" : true
+        });
+
+        // Write commands in enable:
+            // (REG07 bit5 to 0, REG07 bit4 to 0) Disable watchdog 
+            // (REG03 0x3A) Enable charger and min system voltage 
+            // (REG06 0x82) Set charge voltage, 4.352
+            // (REG04 0x20) Set charge current, 2048
+            // (REG09 bit7 to 1) Set charge current optimizer to 1
+            // (REG05 0x13) Set charge termination current limit to default, 256
+        local expected = format("%c%s%c%s%c%s%c%s%c%s%c%s%c%s", 
+            BQ25895M_REG07, "\x9D",
+            BQ25895M_REG07, "\x8D",
+            BQ25895M_REG03, "\x3A",
+            BQ25895M_REG06, "\x82",
+            BQ25895M_REG04, "\x20",
+            BQ25895M_REG09, "\xC4",
+            BQ25895M_REG05, "\x13"        
+        );
+        local actual = _i2c._getWriteBuffer(BQ25895M_DEFAULT_I2C_ADDR);
+        assertEqual(expected, actual, "Enable with charge current optimizer enabled did not match expected results");
+        
+        _cleari2cBuffers();
+        return "Enable with charge current optimizer enabled test passed";
+    }
+
+    function testEnableSetChargeTerminationCurrentLimit() {
+        // Note: Limitation of stubbed class, all read values are set before enable
+        // so 2 set bit calls back to back are not effected by register write commands
+        _cleari2cBuffers();
+        // Set readbuffer values
+        // REG04 to 0x00
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG04.tochar(), "\x00");    
+        // REG05 to 0x10
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG05.tochar(), "\x10");
+        // REG06 to 0x02, 
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG06.tochar(), "\x02");
+        // REG07 to 0x9D,
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG07.tochar(), "\x9D");
+        // REG09 to 0xC4
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG09.tochar(), "\xC4");
+
+        // Test setChargeCurrentOptimizer in range
+        _charger.enable({
+            "setChargeCurrentOptimizer" : false, 
+            "setChargeTerminationCurrentLimit" : 500
+        });
+
+        // Write commands in enable:
+            // (REG07 bit5 to 0, REG07 bit4 to 0) Disable watchdog 
+            // (REG03 0x3A) Enable charger and min system voltage 
+            // (REG06 0x82) Set charge voltage, 4.352
+            // (REG04 0x20) Set charge current, 2048
+            // (REG09 bit7 to 0) Set charge current optimizer to 0
+            // (REG05 0x13) Set charge termination current limit to default, 256
+        local expected = format("%c%s%c%s%c%s%c%s%c%s%c%s%c%s", 
+            BQ25895M_REG07, "\x9D",
+            BQ25895M_REG07, "\x8D",
+            BQ25895M_REG03, "\x3A",
+            BQ25895M_REG06, "\x82",
+            BQ25895M_REG04, "\x20",
+            BQ25895M_REG09, "\x44",
+            BQ25895M_REG05, "\x16"        
+        );
+        local actual = _i2c._getWriteBuffer(BQ25895M_DEFAULT_I2C_ADDR);
+        assertEqual(expected, actual, "Enable setting charge termination current limit in range did not match expected results");
+        
+        // Test setChargeCurrentOptimizer too low
+        _i2c._clearWriteBuffer();
+        _charger.enable({
+            "setChargeTerminationCurrentLimit" : 10
+        });
+
+        // Write commands in enable:
+            // (REG07 bit5 to 0, REG07 bit4 to 0) Disable watchdog 
+            // (REG03 0x3A) Enable charger and min system voltage 
+            // (REG06 0x82) Set charge voltage, 4.352
+            // (REG04 0x20) Set charge current, 2048
+            // (REG09 bit7 to 0) Set charge current optimizer to 0
+            // (REG05 0x10) Set charge termination current limit to 64
+        local expected = format("%c%s%c%s%c%s%c%s%c%s%c%s%c", 
+            BQ25895M_REG07, "\x9D",
+            BQ25895M_REG07, "\x8D",
+            BQ25895M_REG03, "\x3A",
+            BQ25895M_REG06, "\x82",
+            BQ25895M_REG04, "\x20",
+            BQ25895M_REG09, "\x44",
+            BQ25895M_REG05) + "\x10"; // String format with non-printable chars, doesn't always work, use string concat to add last val
+        actual = _i2c._getWriteBuffer(BQ25895M_DEFAULT_I2C_ADDR);
+        assertEqual(expected, actual, "Enable setting charge termination current limit below min did not match expected results");
+    
+        // Test setChargeCurrentOptimizer too high
+        _i2c._clearWriteBuffer();
+        _charger.enable({
+            "setChargeTerminationCurrentLimit" : 2000
+        });
+
+        // Write commands in enable:
+            // (REG07 bit5 to 0, REG07 bit4 to 0) Disable watchdog 
+            // (REG03 0x3A) Enable charger and min system voltage 
+            // (REG06 0x82) Set charge voltage, 4.352
+            // (REG04 0x20) Set charge current, 2048
+            // (REG09 bit7 to 0) Set charge current optimizer to 0
+            // (REG05 0x1F) Set charge termination current limit to 1024
+        local expected = format("%c%s%c%s%c%s%c%s%c%s%c%s%c%s", 
+            BQ25895M_REG07, "\x9D",
+            BQ25895M_REG07, "\x8D",
+            BQ25895M_REG03, "\x3A",
+            BQ25895M_REG06, "\x82",
+            BQ25895M_REG04, "\x20",
+            BQ25895M_REG09, "\x44",
+            BQ25895M_REG05, "\x1F"        
+        );
+        local actual = _i2c._getWriteBuffer(BQ25895M_DEFAULT_I2C_ADDR);
+        assertEqual(expected, actual, "Enable setting charge termination current limit above max did not match expected results");
+        
+        _cleari2cBuffers();
+        return "Enable setting charge termination current limit test passed";
+    }
+
+    function testDisable() {
+        // Note: Limitation of stubbed class, all read values are set before enable
+        // so 2 set bit calls back to back are not effected by register write commands
+        _cleari2cBuffers();
+        // Set readbuffer values
+        // REG03 to 0x3A
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG03.tochar(), "\x3A");    
+        // REG07 to 0x9D,
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG07.tochar(), "\x9D");
+
+        // Test setChargeCurrentOptimizer in range
+        _charger.disable();
+
+        // Test REG03 bit toggles as expected
+        // Write commands in enable:
+            // (REG07 bit5 to 0, REG07 bit4 to 0) Disable watchdog 
+            // (REG03 0x2A) Disable charging (bit 4 set to 0)  
+        local expected = format("%c%s%c%s%c%s", 
+            BQ25895M_REG07, "\x9D",
+            BQ25895M_REG07, "\x8D",
+            BQ25895M_REG03, "\x2A"
+        );
+        local actual = _i2c._getWriteBuffer(BQ25895M_DEFAULT_I2C_ADDR);
+        assertEqual(expected, actual, "Disable did not match expected results");
+        
+        _cleari2cBuffers();
+        return "Disable test passed";
+    }
+
+    function testGetChargeVoltage() {
+        // Test that REG06 set to known val, getChargeVoltage returns expected value
+        _cleari2cBuffers();
+        // Set readbuffer values
+        // REG06 to 0x82
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG06.tochar(), "\x82");
+
+        local expected = 4.352;
+        local actual = _charger.getChargeVoltage();
+        assertEqual(expected, actual, "Get charge voltage did not match expected results");
+        
+        _cleari2cBuffers();
+        return "Get charge voltage test passed";
+    }
+
+    function testGetBatteryVoltage() {
+        // Test that REG0E  set to known val, getBatteryVoltage returns expected value
+        _cleari2cBuffers();
+        // Set readbuffer values
+        // REG02 to 0x00 (need somthing in REG02 for _convStart())
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG02.tochar(), "\x00");
+        // REG0E to 0x00
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG0E.tochar(), "\x07");
+
+        local expected = 2.304 + 0.140;
+        local actual = _charger.getBatteryVoltage();
+        assertEqual(expected, actual, "Get battery voltage did not match expected results");
+        
+        _cleari2cBuffers();
+        return "Get battery voltage test passed";
+    }
+
+    function testGetVBUSVoltage() {
+        // Test that REG11 set to known val, getBatteryVoltage returns expected value
+        _cleari2cBuffers();
+        // Set readbuffer values
+        // REG02 to 0x00 (need somthing in REG02 for _convStart())
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG02.tochar(), "\x00");
+        // REG11 to 0x7F
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG11.tochar(), "\x7F");
+
+        local expected = 15.3;
+        local actual = _charger.getVBUSVoltage();
+        assertEqual(expected, actual, "Get VBUS voltage did not match expected results");
+        
+        _cleari2cBuffers();
+        return "Get VBUS voltage test passed";
+    }
+
+    function testGetSystemVoltage() {
+        // Test that REG0F set to known val, getSystemVoltage returns expected value
+        _cleari2cBuffers();
+        // Set readbuffer values
+        // REG02 to 0x00 (need somthing in REG02 for _convStart())
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG02.tochar(), "\x00");
+        // REG0F to 0x07
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG0F.tochar(), "\x07");
+
+        local expected = 2.304 + 0.140;
+        local actual = _charger.getSystemVoltage();
+        assertEqual(expected, actual, "Get system voltage did not match expected results");
+
+        _cleari2cBuffers();
+        return "Get system voltage test passed";
+    }
+
+    function testGetInputStatus() {
+        // Test that REG0B & REG00 set to known vals, getInputStatus returns expected value
+        _cleari2cBuffers();
+        // Set readbuffer values
+        // REG00 to 0xFF
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG00.tochar(), "\xFF");
+        // REG0B to 0x5F
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG0B.tochar(), "\x5F");
+
+        local expectedVBus   = BQ25895M_VBUS_STATUS.USB_CDP;
+        local expectedInCurr = 3250;
+        local actual = _charger.getInputStatus();
+        assertTrue(("vbusStatus" in actual && "inputCurrentLimit" in actual) "Get input status did return expected table slots");
+        assertEqual(expectedVBus, actual.vbusStatus, "Get input status VBUS status did not match expected results");
+        assertEqual(expectedInCurr, actual.inputCurrentLimit, "Get input status input current limit did not match expected results");
+
+        _cleari2cBuffers();
+        return "Get input status test passed";
+    }
+
+    function testGetChargingCurrent() {
+        // Test that REG12 set to known val, getChargingCurrent returns expected value
+        _cleari2cBuffers();
+        // Set readbuffer values
+        // REG02 to 0x00 (need somthing in REG02 for _convStart())
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG02.tochar(), "\x00");
+        // REG12 to 0x7F
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG12.tochar(), "\x7F");
+
+        local expected = 6350;
+        local actual = _charger.getChargingCurrent();
+        assertEqual(expected, actual, "Get charging current did not match expected results");
+
+        _cleari2cBuffers();
+        return "Get charging current test passed";
+    }
+
+    function testGetChargingStatus() {
+        // Test that REG0B set to known val, getChargingStatus returns expected value
+        _cleari2cBuffers();
+        // Set readbuffer values
+        // REG0B to 0x7F
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG0B.tochar(), "\xF7");
+
+        local expected = BQ25895M_CHARGING_STATUS.FAST_CHARGING;
+        local actual = _charger.getChargingStatus();
+        assertEqual(expected, actual, "Get charging status did not match expected results");
+
+        _cleari2cBuffers();
+        return "Get charging status test passed";
+    }
+
+    function testGetChargerFaults() {
+        // Test that REG0C set to known val, getChargerFaults returns expected value
+        _cleari2cBuffers();
+        // Set readbuffer values
+        // REG0C to 0xFE
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG0C.tochar(), "\xFE");
+
+        local expectedWatchdog   = true;
+        local expectedBoostFault = true;
+        local expectedChrgFault  = BQ25895M_CHARGING_FAULT.CHARGE_SAFETY_TIMER_EXPIRATION;
+        local expectedBattFault  = true;
+        local expectedNtcFault   = BQ25895M_NTC_FAULT.TS_HOT;
+        local actual = _charger.getChargerFaults();
+
+        assertTrue("watchdogFault" in actual, "Get charging faults table missing watchdog slot");
+        assertTrue("boostFault" in actual, "Get charging faults table missing boost slot");
+        assertTrue("chrgFault" in actual, "Get charging faults table missing charge slot");
+        assertTrue("battFault" in actual, "Get charging faults table missing battery slot");
+        assertTrue("ntcFault" in actual, "Get charging faults table missing NTC slot");
+        assertEqual(expectedWatchdog, actual.watchdogFault, "Get charging faults watchdog did not match expected results");
+        assertEqual(expectedBoostFault, actual.boostFault, "Get charging faults boost did not match expected results");
+        assertEqual(expectedChrgFault, actual.chrgFault, "Get charging faults charge did not match expected results");
+        assertEqual(expectedBattFault, actual.battFault, "Get charging faults battery did not match expected results");
+        assertEqual(expectedNtcFault, actual.ntcFault, "Get charging faults NTC did not match expected results");
+
+        _cleari2cBuffers();
+        return "Get charging faults test passed";
+    }
+
+    function testReset() {
+        _cleari2cBuffers();
+        // Set read buffer for toggling register 0x14 bit
+        _i2c._setReadResp(BQ25895M_DEFAULT_I2C_ADDR, BQ25895M_REG14.tochar(), "\x01");
+
+        // Call reset
+        _charger.reset();
+
+        // Write commands in reset:
+            // (REG014 bit7 to 1) Set reset bit
+            // (REG014 bit7 to 0) Clear reset bit
+        local expected = format("%c%s%c%s", 
+            BQ25895M_REG14, "\x81",
+            BQ25895M_REG14, "\x01"
+        );
+
+        local actual = _i2c._getWriteBuffer(BQ25895M_DEFAULT_I2C_ADDR);
+        assertEqual(expected, actual, "Reset did not match expected results");
+        
+        _cleari2cBuffers();
+        return "Reset test passed";
+    }
+
+    function tearDown() {
+        return "Stubbed hardware tests finished.";
+    }
+
+}


### PR DESCRIPTION
- added method to get input status
- added enable setting option to set charge termination current 
- updated enable method parameters (breaking change)
- disabled watchdog, so settings will persist through sleep cycles
  - removed watchdog timer and kick watchdog, as they are not longer needed
- updated docs to reference BQ25895 and BQ25895M support
- updated example 
- bumped version number
- updated license date